### PR TITLE
add support for getting RSSI from connected device

### DIFF
--- a/able/android/jni.py
+++ b/able/android/jni.py
@@ -87,3 +87,8 @@ class PythonBluetooth(PythonJavaClass):
         # characteristic = descriptor.getCharacteristic()
         # uuid = characteristic.getUuid().toString()
         self.dispatcher.dispatch('on_descriptor_write', descriptor, status)
+
+    @java_method('(II)V')
+    def on_rssi_updated(self, rssi, status):
+        self.dispatcher.dispatch('on_gatt_release')
+        self.dispatcher.dispatch('on_rssi_updated', rssi, status)

--- a/able/dispatcher.py
+++ b/able/dispatcher.py
@@ -22,7 +22,7 @@ class BluetoothDispatcherBase(EventDispatcher):
         'on_connection_state_change', 'on_characteristic_changed',
         'on_characteristic_read', 'on_characteristic_write',
         'on_descriptor_read', 'on_descriptor_write',
-        'on_gatt_release', 'on_error',
+        'on_gatt_release', 'on_error', 'on_rssi_updated'
     )
     queue_class = BLEQueue
 
@@ -138,6 +138,13 @@ class BluetoothDispatcherBase(EventDispatcher):
         """
         self._ble.readCharacteristic(characteristic)
 
+    @ble_task
+    def update_rssi(self):
+        """Triggers an update for the RSSI from the associated remote device
+        Event is dispatched at every RSSI update completed operation
+        """
+        self._ble.readRemoteRssi()
+
     def on_error(self, msg):
         """Error handler
 
@@ -233,6 +240,15 @@ class BluetoothDispatcherBase(EventDispatcher):
         """`descriptor_write` event handler
 
         :param descriptor: BluetoothGattDescriptor Java object
+        :param status: status of the operation,
+                       `GATT_SUCCESS` if the operation succeeds
+        """
+        pass
+
+    def on_rssi_updated(self, rssi, status):
+        """`on_rssi_updated` event handler
+
+        :param rssi: integer containing RSSI value in dBm
         :param status: status of the operation,
                        `GATT_SUCCESS` if the operation succeeds
         """

--- a/able/src/org/able/BLE.java
+++ b/able/src/org/able/BLE.java
@@ -164,6 +164,10 @@ public class BLE {
                                 mPython.on_descriptor_write(descriptor, status);
                         }
 
+			public void onReadRemoteRssi(BluetoothGatt gatt,
+						     int rssi, int status) {
+				mPython.on_rssi_updated(rssi, status);
+			}
                 };
 
         public boolean writeCharacteristic(BluetoothGattCharacteristic characteristic, byte[] data) {
@@ -184,4 +188,8 @@ public class BLE {
         public boolean readCharacteristic(BluetoothGattCharacteristic characteristic) {
                 return mBluetoothGatt.readCharacteristic(characteristic);
         }
+
+	public boolean readRemoteRssi() {
+		return mBluetoothGatt.readRemoteRssi();
+	}
 }

--- a/able/src/org/able/PythonBluetooth.java
+++ b/able/src/org/able/PythonBluetooth.java
@@ -19,4 +19,5 @@ interface PythonBluetooth
         public void on_descriptor_read(BluetoothGattDescriptor descriptor, int status);
         public void on_descriptor_write(BluetoothGattDescriptor descriptor, int status);
         public void on_connection_state_change(int status, int state);
+	public void on_rssi_updated(int rssi, int status);
 }


### PR DESCRIPTION
Hello

I've added support for getting updated RSSI information from connected devices. I've tested it on a real device and it seems I can plot the RSSI on a kivy plot; it seems I'm getting reasonable values, so I'd say it works.

The APIs have been extended with the _update_rssi()_ method to request for updating the RSSI, and the _on_rssi_updated(self, rssi, status)_  event which will trigger once the updated RSSI value is available.

I've tried to do this in a coherent way with respect to able design; I've been a bit in doubt about the the two "dispatcher.py" files (i.e. whether to put the new code in BluetoothDispatcher vs BluetoothDispatcherBase).. Please let me know whether I did it in the proper way :)

Andrea
