### PR TITLE
Gatt must be closed on disconnect. If not, connectGatt won't reconnect.

### DIFF
--- a/able/src/org/able/BLE.java
+++ b/able/src/org/able/BLE.java
@@ -158,6 +158,8 @@ public class BLE {
                 Log.d(TAG, "connectGatt");
                 if (mBluetoothGatt == null) {
                         mBluetoothGatt = device.connectGatt(mContext, false, mGattCallback, BluetoothDevice.TRANSPORT_LE);
+                } else {
+                        Log.d(TAG, "BluetoothGatt object exists, use either closeGatt() to close Gatt or BluetoothGatt.connect() to re-connect");
                 }
         }
 


### PR DESCRIPTION
ABLE was not able to reconnect when walking out of range.

This was due to the connectGatt method. After walking out of range, the mBluetoothGatt object was not equal to null. Thereby blocking the ability to reconnect. When walking of out range, the onConnectionStateChanged method is called. In my case with state disconnected en status 8. To fix the connectGatt problem, it is sufficient to close the gatt connection when onConnectionStateChanged is called with state argument STATE_DISCONNECTED.